### PR TITLE
#478 - Create tests for Datasource.Close()

### DIFF
--- a/westack/tests/server/datasources.json
+++ b/westack/tests/server/datasources.json
@@ -44,6 +44,18 @@
     "allowExtendedOperators": true,
     "retryOnError": true
   },
+  "db_expected_to_be_closed": {
+    "host": "127.0.0.1",
+    "port": 27017,
+    "database": "example_db_expected_to_be_closed",
+    "password": "",
+    "name": "db_expected_to_be_closed",
+    "username": "",
+    "connector": "mongodb",
+    "useNewUrlParser": true,
+    "allowExtendedOperators": true,
+    "retryOnError": true
+  },
   "memorykv": {
     "name": "memorykv",
     "url": "localhost:0",

--- a/westack/tests/westack_datasource_test.go
+++ b/westack/tests/westack_datasource_test.go
@@ -54,6 +54,13 @@ func Test_DatasourceClose(t *testing.T) {
 	err = ds.Close()
 	assert.NoError(t, err)
 
+	// Based on suggestion from @tanryberdi: https://github.com/fredyk/westack-go/pull/480#discussion_r1312634782
+	// Attempt to perform a query. We don't mind the queried collection because the client
+	// is disconnected anyway
+	result, err := ds.FindMany("unknownCollection", nil)
+	assert.Errorf(t, err, "client is disconnected")
+	assert.Nil(t, result)
+
 }
 
 func Test_Datasource_Ping(t *testing.T) {

--- a/westack/tests/westack_datasource_test.go
+++ b/westack/tests/westack_datasource_test.go
@@ -43,6 +43,19 @@ func Test_Datasource_Initialize_ConnectError(t *testing.T) {
 
 }
 
+func Test_DatasourceClose(t *testing.T) {
+
+	t.Parallel()
+
+	ds, err := app.FindDatasource("db_expected_to_be_closed")
+	assert.NoError(t, err)
+	assert.NotNil(t, ds)
+
+	err = ds.Close()
+	assert.NoError(t, err)
+
+}
+
 func Test_Datasource_Ping(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
Issue: https://github.com/fredyk/westack-go/issues/478